### PR TITLE
Destroy cannons when they are hit

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -13,6 +13,7 @@
         <entry key="..\:/Users/VChan/Desktop/sprint2TD/Trivia-Defender/TriviaDefender/app/src/main/res/layout/activity_game.xml" value="0.17831813576494426" />
         <entry key="..\:/Users/ldolp/Documents/GitHub/Trivia-Defender/TriviaDefender/app/src/main/res/layout/activity_game.xml" value="0.18802083333333333" />
         <entry key="..\:/Users/ldolp/Documents/GitHub/Trivia-Defender/TriviaDefender/app/src/main/res/layout/activity_main.xml" value="0.18802083333333333" />
+        <entry key="..\:/Users/ldolp/Documents/GitHub/Trivia-Defender/app/src/main/res/layout/activity_game.xml" value="0.18802083333333333" />
       </map>
     </option>
   </component>

--- a/app/src/main/java/com/example/triviadefender/GameActivity.java
+++ b/app/src/main/java/com/example/triviadefender/GameActivity.java
@@ -182,4 +182,7 @@ public class GameActivity extends AppCompatActivity {
         missileMaker.applyInterceptorBlast(cannonFire, id);
         questionMaker.applyInterceptorBlast(cannonFire, id); //To check if any questions got hit
     }
+    public ArrayList<ImageView> getActiveCannons() {
+        return activeCannons;
+    }
 }

--- a/app/src/main/java/com/example/triviadefender/MissileMaker.java
+++ b/app/src/main/java/com/example/triviadefender/MissileMaker.java
@@ -6,6 +6,7 @@ import android.animation.AnimatorSet;
 import android.util.Log;
 import android.widget.ImageView;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 public class MissileMaker implements Runnable {
@@ -19,9 +20,6 @@ public class MissileMaker implements Runnable {
     private int MISSILES_PER_LEVEL = 10;
     private static final int SLEEP_BETWEEN_LEVELS = 2000;
     private long delay = 5000;
-
-
-    public static ArrayList<ImageView> bases = new ArrayList<>();
 
     MissileMaker(GameActivity gameActivity, int screenWidth, int screenHeight) {
         this.gameActivity = gameActivity;
@@ -121,14 +119,16 @@ public class MissileMaker implements Runnable {
 
         Log.d(TAG, "applyMissileBlast: -------------------------- " + id);
 
+        //Get the available cannons from gameActivity where they were initialized
+        ArrayList<ImageView> activeCannons = gameActivity.getActiveCannons();
+
         float x1 = missile.getX();
         float y1 = missile.getY();
 
         Log.d(TAG, "applyMissileBlast: MISSILE: " + x1 + ", " + y1);
-
         ImageView baseToRemove = null;
-        for (ImageView iv : bases) {
 
+        for (ImageView iv : activeCannons) {
             //Get size of the base image
             float x2 = (int) (iv.getX() + (0.5 * iv.getWidth()));
             float y2 = (int) (iv.getY() + (0.5 * iv.getHeight()));
@@ -153,9 +153,9 @@ public class MissileMaker implements Runnable {
         if (baseToRemove == null) {
             SoundPlayer.getInstance().start("missile_miss");
         } else {
-            bases.remove(baseToRemove);
+            activeCannons.remove(baseToRemove);
             /*
-            if(bases.size()<1){
+            if(activeCannons.size()<1){
                 gameActivity.gameOver();
             }
             */

--- a/app/src/main/res/layout/activity_game.xml
+++ b/app/src/main/res/layout/activity_game.xml
@@ -23,15 +23,15 @@
         android:layout_height="wrap_content"
         android:contentDescription="@null"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/Cannon3"
-        app:layout_constraintStart_toEndOf="@+id/Cannon1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:srcCompat="@drawable/base" />
 
     <ImageView
         android:id="@+id/Cannon3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="50dp"
+        android:layout_marginEnd="52dp"
         android:contentDescription="@null"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Added getActiveCannons to gameActivity so other classes can pull the list of cannons
Updated the cannons in the XML to not move when a side cannon is destroyed
Updated MissileMaker to pull from GameActivity and renamed bases to activeCannons